### PR TITLE
monitor.js catch errors

### DIFF
--- a/monitor.js
+++ b/monitor.js
@@ -15,16 +15,19 @@ export async function main(ns) {
     while (true) {
         const server = flags._[0];
         let money = ns.getServerMoneyAvailable(server);
-        if (money === 0) money = 1;
         const maxMoney = ns.getServerMaxMoney(server);
         const minSec = ns.getServerMinSecurityLevel(server);
         const sec = ns.getServerSecurityLevel(server);
         ns.clearLog(server);
         ns.print(`${server}:`);
-        ns.print(` $_______: ${ns.nFormat(money, "$0.000a")} / ${ns.nFormat(maxMoney, "$0.000a")} (${(money / maxMoney * 100).toFixed(2)}%)`);
+        if (money < 1) {
+            ns.print(` $_______: ${ns.nFormat(money, "$0.000a")} / ${ns.nFormat(maxMoney, "$0.000a")} (ERROR MONEY IS ${money})`);
+        } else { ns.print(` $_______: ${ns.nFormat(money, "$0.000a")} / ${ns.nFormat(maxMoney, "$0.000a")} (${(money / maxMoney * 100).toFixed(2)}%)`) }
         ns.print(` security: +${(sec - minSec).toFixed(2)}`);
         ns.print(` hack____: ${ns.tFormat(ns.getHackTime(server))} (t=${Math.ceil(ns.hackAnalyzeThreads(server, money))})`);
-        ns.print(` grow____: ${ns.tFormat(ns.getGrowTime(server))} (t=${Math.ceil(ns.growthAnalyze(server, maxMoney / money))})`);
+        if (money < 1) {
+            ns.print(` grow____: ${ns.tFormat(ns.getGrowTime(server))} (ERROR GROWTH IS 0)`);
+        } else { ns.print(` grow____: ${ns.tFormat(ns.getGrowTime(server))} (t=${Math.ceil(ns.growthAnalyze(server, maxMoney / money))})`) }
         ns.print(` weaken__: ${ns.tFormat(ns.getWeakenTime(server))} (t=${Math.ceil((sec - minSec) * 20)})`);
         await ns.sleep(flags.refreshrate);
     }


### PR DESCRIPTION
I removed the hacky and inaccurate `if (money === 0) money = 1;` statement. This would cause `money > maxMoney`.
In place of this I added 2 statements related to `money < 1` which triggered `$_______: $0.000 / $0.000 (NaN%)` to print. 
This should be fine but doesn't make it easy at a glance that something is wrong. 
So a Error statement is printed, turning it red with an explanation.
Variables can be made static text but isn't required so I didn't bother.

Then for the `grow____:` line, it would crash because of `maxMoney / money`, example: `0 / 1` as it was before and `0/0` after removing `if (money === 0) money = 1;`
Both cases it expects a number above 1 but it isn't returned. Instead of patching it with another lied 1 as money had, I check `money < 1` and print an error.

This results in the following:
![New result without script crash.](https://i.imgur.com/LqOrlf4.pngg)

Instead of:
![Original result that created an error causing a script crash.](https://i.imgur.com/AsxvKY6.png)