### PR TITLE
Update deploy.js

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -24,6 +24,6 @@ export async function main(ns) {
 
 	const threads = Math.floor((ns.getServerMaxRam(host) - ns.getServerUsedRam(host)) / ns.getScriptRam(script));
 	ns.tprint(`Launching script '${script}' on server '${host}' with ${threads} threads and the following arguments: ${script_args}`);
-	await ns.scp(script, ns.getHostname(), host);
+	await ns.scp(script, host, ns.getHostname());
 	ns.exec(script, host, threads, ...script_args);
 }


### PR DESCRIPTION
The arguments for ns.scp() were swapped, causing an error when copying the script. Would be confusing for a new player.